### PR TITLE
Fix compiler bug in gcc 10.1

### DIFF
--- a/linalg.h
+++ b/linalg.h
@@ -53,6 +53,7 @@
 #include <array>        // For std::array
 #include <iosfwd>       // For forward definitions of std::ostream
 #include <type_traits>  // For std::enable_if, std::is_same, std::declval
+#include <functional>   // For std::hash declaration
 
 // In Visual Studio 2015, `constexpr` applied to a member function implies `const`, which causes ambiguous overload resolution
 #if _MSC_VER <= 1900


### PR DESCRIPTION
In gcc 10.1 std::hash is not visible and the specializations `template<class T> struct hash<linalg::vec<T,1>>` do not work due to the original `struct hash` not being visible. Fix it by including `<functional>`. where `std::hash` is defined.