### PR TITLE
Fix error in linalg::swizzle

### DIFF
--- a/linalg.h
+++ b/linalg.h
@@ -431,7 +431,7 @@ namespace linalg
     template<class A, class B> constexpr auto operator >>= (A & a, const B & b) -> decltype(a = a >> b) { return a = a >> b; }
 
     // Swizzles and subobjects
-    template<int... I, class T, int M>                              constexpr vec<T,sizeof...(I)>   swizzle(const vec<T,M> & a)   { return {detail::getter<I>(a)...}; }
+    template<int... I, class T, int M>                              constexpr vec<T,sizeof...(I)>   swizzle(const vec<T,M> & a)   { return {detail::getter<I>{}(a)...}; }
     template<int I0, int I1, class T, int M>                        constexpr vec<T,I1-I0>          subvec (const vec<T,M> & a)   { return detail::swizzle(a, detail::make_seq<I0,I1>{}); }
     template<int I0, int J0, int I1, int J1, class T, int M, int N> constexpr mat<T,I1-I0,J1-J0>    submat (const mat<T,M,N> & a) { return detail::swizzle(a, detail::make_seq<I0,I1>{}, detail::make_seq<J0,J1>{}); }
 


### PR DESCRIPTION
I was getting a compile error like `no matching conversion for functional-style cast from 'const vec<double, 3>' to 'detail::getter<2>'` when trying to use `swizzle`. 

It seems as written we're trying to construct a `detail::getter` with a vec, whereas we want to be default-constructing a `getter` and then invoking `operator()`. Typo probably? This patch does just that, and fixes the error.

Using clang 11.0.3 if it matters.